### PR TITLE
Refactor MCP client using Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.14.0",
     "httpx>=0.28.1",
+    "pydantic>=2.7.0",
 ]
 authors = [{ name = "Jaebok Lee" }]
 

--- a/src/client.py
+++ b/src/client.py
@@ -1,42 +1,78 @@
+"""Client for interacting with the Wikidata MCP server.
+
+This module defines pydantic models for configuration and requests,
+which provides validation and type safety for the client. It connects to the
+local MCP server defined in ``server.py`` and queries it using LangChain's
+React agent.
+"""
+
+from __future__ import annotations
+
 import os
+from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
-
-os.environ["OPENAI_API_KEY"] = "your-api-key"
-
-model = ChatOpenAI(model="gpt-4o")
-
-server_py = os.path.join(os.path.dirname(os.path.abspath(__file__)), "server.py")
-server_params = StdioServerParameters(
-    command="python",
-    args=[server_py],
-)
+from pydantic import BaseModel, BaseSettings, Field
 
 
-async def main():
+class ClientSettings(BaseSettings):
+    """Configuration for the MCP client.
+
+    Attributes:
+        openai_api_key: API key for OpenAI. Loaded from the ``OPENAI_API_KEY``
+            environment variable.
+        model: Name of the OpenAI chat model to use.
+        prompt: Default system prompt for the React agent.
+    """
+
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    model: str = "gpt-4o"
+    prompt: str = (
+        "You are a helpful assistant. Answer the user's questions based on Wikidata."
+    )
+
+
+class ServerConfig(BaseModel):
+    """Configuration for starting the MCP server."""
+
+    command: str = "python"
+    script: Path = Path(__file__).resolve().parent / "server.py"
+
+    def to_stdio_params(self) -> StdioServerParameters:
+        """Convert the server configuration to ``StdioServerParameters``."""
+
+        return StdioServerParameters(command=self.command, args=[str(self.script)])
+
+
+class AgentRequest(BaseModel):
+    """Schema for requests sent to the agent."""
+
+    messages: str
+
+
+async def main() -> None:
+    settings = ClientSettings()
+    os.environ["OPENAI_API_KEY"] = settings.openai_api_key
+
+    model = ChatOpenAI(model=settings.model)
+    server_params = ServerConfig().to_stdio_params()
+
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            # Get tools
             tools = await load_mcp_tools(session)
 
-            # Create and run the agent
-            agent = create_react_agent(
-                model,
-                tools,
-                prompt="You are a helpful assistant. Answer the user's questions based on Wikidata.",
+            agent = create_react_agent(model, tools, prompt=settings.prompt)
+
+            request = AgentRequest(
+                messages="Can you recommend me a movie directed by Bong Joonho?"
             )
-            agent_response = await agent.ainvoke(
-                {
-                    "messages": "Can you recommend me a movie directed by Bong Joonho?",
-                }
-            )
+            agent_response = await agent.ainvoke(request.model_dump())
             print(agent_response)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -484,6 +484,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
@@ -504,6 +505,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'example'", specifier = ">=0.3.33" },
     { name = "langgraph", marker = "extra == 'example'", specifier = ">=0.6.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.14.0" },
+    { name = "pydantic", specifier = ">=2.7.0" },
 ]
 provides-extras = ["example"]
 


### PR DESCRIPTION
## Summary
- add Pydantic as a dependency
- refactor MCP client to use Pydantic models for settings and requests

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c522b21ba08326ab0df2646881e7b7

## Summary by Sourcery

Refactor the MCP client to leverage Pydantic for configuration, server parameters, and request validation, and update the main entrypoint to use these models.

New Features:
- Introduce ClientSettings, ServerConfig, and AgentRequest Pydantic models for type-safe configuration and request schemas.

Enhancements:
- Refactor main() to load OpenAI settings from ClientSettings, derive server parameters via ServerConfig, and use Pydantic for request payloads.
- Replace hard-coded API key and server invocation logic with environment-driven and model-based configurations.

Build:
- Add pydantic>=2.7.0 to project dependencies in pyproject.toml.

Documentation:
- Add module-level docstring to describe Pydantic models and client behavior.