### PR TITLE
Refactor MCP client using Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.14.0",
     "httpx>=0.28.1",
+    "pydantic>=2.7.0",
 ]
 authors = [{ name = "Jaebok Lee" }]
 

--- a/src/client.py
+++ b/src/client.py
@@ -1,40 +1,75 @@
-import os
+"""Client for interacting with the Wikidata MCP server.
+
+This module defines a pydantic ``Config`` object that encapsulates both
+environment-driven settings and server configuration. It connects to the local
+MCP server defined in ``server.py`` and queries it using LangChain's React
+agent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langgraph.prebuilt import create_react_agent
 from langchain_openai import ChatOpenAI
-
-os.environ["OPENAI_API_KEY"] = "your-api-key"
-
-model = ChatOpenAI(model="gpt-4o")
-
-server_py = os.path.join(os.path.dirname(os.path.abspath(__file__)), "server.py")
-server_params = StdioServerParameters(
-    command="python",
-    args=[server_py],
-)
+from pydantic import BaseSettings, Field
 
 
-async def main():
+class Config(BaseSettings):
+    """Settings for the MCP client and server.
+
+    Attributes:
+        openai_api_key: API key for OpenAI. Loaded from ``OPENAI_API_KEY``.
+        model: Name of the OpenAI chat model to use. Can be overridden with
+            ``MCP_MODEL``.
+        prompt: Default system prompt for the React agent. Can be overridden
+            with ``MCP_PROMPT``.
+        server_cmd: Executable used to launch the MCP server.
+        server_script: Path to the MCP server script.
+    """
+
+    openai_api_key: str = Field(..., env="OPENAI_API_KEY")
+    model: str = Field("gpt-4o", env="MCP_MODEL")
+    prompt: str = Field(
+        "You are a helpful assistant. Answer the user's questions based on Wikidata.",
+        env="MCP_PROMPT",
+    )
+    server_cmd: str = "python"
+    server_script: Path = Path(__file__).resolve().parent / "server.py"
+
+    def stdio_params(self) -> StdioServerParameters:
+        """Return parameters for launching the MCP server via stdio."""
+
+        return StdioServerParameters(
+            command=self.server_cmd, args=[str(self.server_script)]
+        )
+
+
+async def main() -> None:
+    cfg = Config()
+
+    model = ChatOpenAI(model=cfg.model, api_key=cfg.openai_api_key)
+    server_params = cfg.stdio_params()
+
     async with stdio_client(server_params) as (read, write):
         async with ClientSession(read, write) as session:
-            # Initialize the connection
             await session.initialize()
 
-            # Get tools
             tools = await load_mcp_tools(session)
 
-            # Create and run the agent
-            agent = create_react_agent(
-                model,
-                tools,
-                prompt="You are a helpful assistant. Answer the user's questions based on Wikidata.",
-            )
+            agent = create_react_agent(model, tools, prompt=cfg.prompt)
+
             agent_response = await agent.ainvoke(
                 {
-                    "messages": "Can you recommend me a movie directed by Bong Joonho?",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Can you recommend me a movie directed by Bong Joonho?",
+                        }
+                    ]
                 }
             )
             print(agent_response)

--- a/uv.lock
+++ b/uv.lock
@@ -484,6 +484,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
@@ -504,6 +505,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'example'", specifier = ">=0.3.33" },
     { name = "langgraph", marker = "extra == 'example'", specifier = ">=0.6.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.14.0" },
+    { name = "pydantic", specifier = ">=2.7.0" },
 ]
 provides-extras = ["example"]
 


### PR DESCRIPTION
## Summary
- consolidate configuration and request handling into a single Pydantic `Config`
- allow overriding model and prompt via environment variables and pass API key directly to `ChatOpenAI`
- support a list of chat messages in agent invocations

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c522b21ba08326ab0df2646881e7b7

## Summary by Sourcery

Refactor the MCP client to use a Pydantic configuration object for environment-driven settings, enable model and prompt overrides, and update the agent invocation to accept structured chat messages

New Features:
- Introduce a Pydantic BaseSettings Config to centralize client and server settings
- Allow overriding the OpenAI model and system prompt via MCP_MODEL and MCP_PROMPT environment variables
- Support invoking the chat agent with a list of chat messages instead of a single string

Enhancements:
- Pass the OpenAI API key directly into ChatOpenAI from environment settings
- Add a stdio_params method on the Config class to generate server launch parameters

Build:
- Add pydantic>=2.7.0 to project dependencies